### PR TITLE
Allow setting config over environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,7 @@ RUN apk -Uuv add python py-pip && \
 	rm /var/cache/apk/*
 
 ADD https://github.com/s12v/sns/releases/download/$VERSION/sns-$VERSION.jar /sns.jar
+ADD entrypoint.sh /opt/entrypoint.sh
 
+ENTRYPOINT ["/opt/entrypoint.sh"]
 CMD ["java", "-jar", "/sns.jar"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
-echo $DB_CONFIG > /etc/sns/db.json
-echo "Wrote config, running SNS"
+if [ "$(echo $DB_CONFIG | xargs)" != "" ]; then
+  echo $DB_CONFIG > /etc/sns/db.json
+  echo "Wrote config, running SNS"
+fi
+
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo $DB_CONFIG > /etc/sns/db.json
+echo "Wrote config, running SNS"
+exec "$@"


### PR DESCRIPTION
This is useful so we don't have to mount config as a volume, instead you can just set it as an environment variable.
