### PR TITLE
Improve SNS API compatibility for messages

### DIFF
--- a/features/step_definitions/publish.rb
+++ b/features/step_definitions/publish.rb
@@ -36,7 +36,7 @@ Then(/^I should see "([^"]*)" in queue "([^"]*)"$/) do |message, queue_url|
 
   found = false
   response.messages.each do |m|
-    if m.body == message
+    if m.body.index(message)
       found = true
       $SQS.delete_message({
                             queue_url: queue_url,

--- a/src/main/scala/me/snov/sns/actor/ProducerActor.scala
+++ b/src/main/scala/me/snov/sns/actor/ProducerActor.scala
@@ -1,12 +1,26 @@
 package me.snov.sns.actor
 
 import akka.actor.{Actor, ActorLogging, Props}
-import akka.camel.Oneway
+import akka.camel.{CamelMessage,Oneway}
+
+import spray.json._
+
+import me.snov.sns.model.Message
 
 object ProducerActor {
-  def props(endpoint: String) = Props(classOf[ProducerActor], endpoint)
+  def props(endpoint: String, subscriptionArn: String, topicArn: String) = Props(classOf[ProducerActor], endpoint, subscriptionArn, topicArn)
 }
 
-class ProducerActor(endpoint: String) extends Actor with Oneway with ActorLogging {
+class ProducerActor(endpoint: String, subscriptionArn: String, topicArn: String) extends Actor with Oneway with ActorLogging {
   def endpointUri = endpoint
+
+  override def transformOutgoingMessage(msg: Any) = msg match {
+    case snsMsg: Message => new CamelMessage(snsMsg.toJson.toString, Map(
+        CamelMessage.MessageExchangeId -> snsMsg.uuid,
+        "x-amz-sns-message-type" -> "Notification",
+        "x-amz-sns-message-id" -> snsMsg.uuid,
+        "x-amz-sns-subscription-arn" -> subscriptionArn,
+        "x-amz-sns-topic-arn" -> topicArn
+      ))
+  }
 }

--- a/src/main/scala/me/snov/sns/actor/PublishActor.scala
+++ b/src/main/scala/me/snov/sns/actor/PublishActor.scala
@@ -7,14 +7,14 @@ import me.snov.sns.model.Message
 object PublishActor {
   def props(actor: ActorRef) = Props(classOf[PublishActor], actor)
 
-  case class CmdPublish(topicArn: String, message: String)
+  case class CmdPublish(topicArn: String, body: String)
 }
 
 class PublishActor(subscribeActor: ActorRef) extends Actor with ActorLogging {
   import me.snov.sns.actor.PublishActor._
   
-  private def publish(topicArn: String, messageString: String): Message = {
-    val message = Message(messageString)
+  private def publish(topicArn: String, body: String): Message = {
+    val message = Message(body)
 
     // todo ask
     subscribeActor ! CmdFanOut(topicArn, message)

--- a/src/main/scala/me/snov/sns/actor/PublishActor.scala
+++ b/src/main/scala/me/snov/sns/actor/PublishActor.scala
@@ -7,14 +7,14 @@ import me.snov.sns.model.Message
 object PublishActor {
   def props(actor: ActorRef) = Props(classOf[PublishActor], actor)
 
-  case class CmdPublish(topicArn: String, body: String)
+  case class CmdPublish(topicArn: String, bodies: Map[String, String])
 }
 
 class PublishActor(subscribeActor: ActorRef) extends Actor with ActorLogging {
   import me.snov.sns.actor.PublishActor._
   
-  private def publish(topicArn: String, body: String): Message = {
-    val message = Message(body)
+  private def publish(topicArn: String, bodies: Map[String, String]): Message = {
+    val message = Message(bodies)
 
     // todo ask
     subscribeActor ! CmdFanOut(topicArn, message)
@@ -23,6 +23,6 @@ class PublishActor(subscribeActor: ActorRef) extends Actor with ActorLogging {
   }
   
   override def receive = {
-    case CmdPublish(topicArn, message) => sender ! publish(topicArn, message)
+    case CmdPublish(topicArn, bodies) => sender ! publish(topicArn, bodies)
   }
 }

--- a/src/main/scala/me/snov/sns/actor/SubscribeActor.scala
+++ b/src/main/scala/me/snov/sns/actor/SubscribeActor.scala
@@ -43,7 +43,7 @@ class SubscribeActor(dbActor: ActorRef) extends Actor with ActorLogging {
         subscriptions.get(topicArn).get.foreach((s: Subscription) => {
           if (actorPool.isDefinedAt(s)) {
             log.debug(s"Sending message ${message.uuid} to ${s.endpoint}")
-            actorPool(s) ! message.body
+            actorPool(s) ! message
           } else {
             throw new RuntimeException(s"No actor for subscription ${s.endpoint}")
           }
@@ -68,7 +68,7 @@ class SubscribeActor(dbActor: ActorRef) extends Actor with ActorLogging {
   }
 
   def initSubscription(subscription: Subscription) = {
-    val producer = context.system.actorOf(ProducerActor.props(subscription.endpoint))
+    val producer = context.system.actorOf(ProducerActor.props(subscription.endpoint, subscription.arn, subscription.topicArn))
     val listByTopic = subscription :: subscriptions.getOrElse(subscription.topicArn, List())
 
     actorPool += (subscription -> producer)

--- a/src/main/scala/me/snov/sns/model/Message.scala
+++ b/src/main/scala/me/snov/sns/model/Message.scala
@@ -1,7 +1,25 @@
 package me.snov.sns.model
 
+import spray.json._
+
 import java.util.UUID
 
-case class Message(body: String) {
-  val uuid = UUID.randomUUID()
+case class Message(body: String, uuid: UUID = UUID.randomUUID) {
+}
+
+object Message extends DefaultJsonProtocol {
+  implicit object MessageJsonFormat extends RootJsonFormat[Message] {
+    def write(msg: Message) = JsObject(
+      "MessageId" -> JsString(msg.uuid.toString),
+      "Message" -> JsString(msg.body),
+      "Type" -> JsString("Notification")
+    )
+
+    def read(value: JsValue) = {
+      value.asJsObject.getFields("MessageId", "Message", "Type") match {
+        case Seq(JsString(uuid), JsString(body), _) => new Message(body, UUID.fromString(uuid))
+        case _ => throw new DeserializationException("Message expected")
+      }
+    }
+  }
 }

--- a/src/main/scala/me/snov/sns/model/Message.scala
+++ b/src/main/scala/me/snov/sns/model/Message.scala
@@ -4,20 +4,20 @@ import spray.json._
 
 import java.util.UUID
 
-case class Message(body: String, uuid: UUID = UUID.randomUUID) {
+case class Message(bodies: Map[String, String], uuid: UUID = UUID.randomUUID) {
 }
 
 object Message extends DefaultJsonProtocol {
   implicit object MessageJsonFormat extends RootJsonFormat[Message] {
     def write(msg: Message) = JsObject(
       "MessageId" -> JsString(msg.uuid.toString),
-      "Message" -> JsString(msg.body),
+      "Message" -> JsString(msg.bodies.getOrElse("default", "")),
       "Type" -> JsString("Notification")
     )
 
     def read(value: JsValue) = {
       value.asJsObject.getFields("MessageId", "Message", "Type") match {
-        case Seq(JsString(uuid), JsString(body), _) => new Message(body, UUID.fromString(uuid))
+        case Seq(JsString(uuid), JsString(body), _) => new Message(Map("default" -> body), UUID.fromString(uuid))
         case _ => throw new DeserializationException("Message expected")
       }
     }

--- a/src/test/scala/me/snov/sns/api/PublishSpec.scala
+++ b/src/test/scala/me/snov/sns/api/PublishSpec.scala
@@ -24,7 +24,7 @@ class PublishSpec extends WordSpec with Matchers with ScalatestRouteTest {
     }
   }
 
-  "Sends subscribe command" in {
+  "Sends publish command" in {
     val params = Map(
       "Action" -> "Publish",
       "TopicArn" -> "foo",

--- a/src/test/scala/me/snov/sns/api/PublishSpec.scala
+++ b/src/test/scala/me/snov/sns/api/PublishSpec.scala
@@ -3,7 +3,7 @@ package me.snov.sns.api
 import java.util.concurrent.TimeUnit
 
 import akka.actor.ActorRef
-import akka.http.scaladsl.model.{FormData, HttpResponse, StatusCodes}
+import akka.http.scaladsl.model.{FormData,StatusCodes}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.testkit.{TestActor, TestProbe}
 import akka.util.Timeout

--- a/src/test/scala/me/snov/sns/api/PublishSpec.scala
+++ b/src/test/scala/me/snov/sns/api/PublishSpec.scala
@@ -33,12 +33,12 @@ class PublishSpec extends WordSpec with Matchers with ScalatestRouteTest {
 
     probe.setAutoPilot(new TestActor.AutoPilot {
       def run(sender: ActorRef, msg: Any) = {
-        sender ! Message("foo")
+        sender ! Message(Map("default" -> "foo"))
         this
       }
     })
     Post("/", FormData(params)) ~> route ~> check {
-      probe.expectMsg(CmdPublish("foo", "bar"))
+      probe.expectMsg(CmdPublish("foo", Map("default" -> "bar")))
     }
   }
 }


### PR DESCRIPTION
* produce JSON with minimal metadata just like SNS would
* produce the correct HTTP headers (fixes #25)
* fake out the support for the `MessageStructure` request property