### PR TITLE
Format the subscription ARN to match AWS' behavior

### DIFF
--- a/src/main/scala/me/snov/sns/actor/SubscribeActor.scala
+++ b/src/main/scala/me/snov/sns/actor/SubscribeActor.scala
@@ -59,7 +59,7 @@ class SubscribeActor(dbActor: ActorRef) extends Actor with ActorLogging {
   }
 
   def subscribe(topicArn: TopicArn, protocol: String, endpoint: String): Subscription = {
-    val subscription = Subscription(UUID.randomUUID().toString, "", topicArn, protocol, endpoint)
+    val subscription = Subscription(s"${topicArn}:${UUID.randomUUID}", "", topicArn, protocol, endpoint)
     initSubscription(subscription)
     
     save()


### PR DESCRIPTION
Instead of using a random UUID alone we're now concatenating the (valid) topic ARN with the UUID,
so that the subscription ARN is also a valid ARN (and incidentally contains the topic for easier debugging)