### PR TITLE
Fix to use memory only store

### DIFF
--- a/src/main/scala/me/snov/sns/Main.scala
+++ b/src/main/scala/me/snov/sns/Main.scala
@@ -10,7 +10,7 @@ import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import me.snov.sns.actor._
 import me.snov.sns.api._
-import me.snov.sns.service.DbService
+import me.snov.sns.service.FileDbService
 import me.snov.sns.util.ToStrict
 
 import scala.concurrent.ExecutionContext
@@ -25,7 +25,7 @@ object Main extends App with ToStrict {
   implicit val timeout = new Timeout(1.second)
 
   val config = ConfigFactory.load()
-  val dbService = new DbService(Properties.envOrElse("DB_PATH", config.getString("db.path")))
+  val dbService = new FileDbService(Properties.envOrElse("DB_PATH", config.getString("db.path")))
 
   val dbActor = system.actorOf(DbActor.props(dbService), name = "DbActor")
   val homeActor = system.actorOf(HomeActor.props, name = "HomeActor")

--- a/src/main/scala/me/snov/sns/service/DbService.scala
+++ b/src/main/scala/me/snov/sns/service/DbService.scala
@@ -4,10 +4,24 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths, StandardOpenOption}
 
 import akka.event.LoggingAdapter
-import me.snov.sns.model.Configuration
+import me.snov.sns.model.{Configuration, Subscription, Topic}
 import spray.json._
 
-class DbService(dbFilePath: String)(implicit log: LoggingAdapter) {
+trait DbService {
+  def load(): Option[Configuration]
+
+  def save(configuration: Configuration)
+}
+
+class MemoryDbService extends DbService {
+  override def load(): Option[Configuration] = {
+    Some(Configuration(subscriptions= List[Subscription](), topics= List[Topic]()))
+  }
+
+  override def save(configuration: Configuration): Unit = {}
+}
+
+class FileDbService(dbFilePath: String)(implicit log: LoggingAdapter) extends DbService {
 
   val subscriptionsName = "subscriptions"
   val topicsName = "topics"


### PR DESCRIPTION
Hi Sergey

I used your library to test my integration with amazon sns, great work you did in this project, you helped me a lot.

I needed change one thing, I use your library embedded in my tests, so that way I don't need to store the state on file, because of that I created one abstraction to use with my tests, I think it could help other people to use it that way too. 

What do you think about it?