### PR TITLE
Fixes 'Connection refused' issue when running the example docker file.

### DIFF
--- a/example/config/elasticmq.conf
+++ b/example/config/elasticmq.conf
@@ -1,0 +1,9 @@
+include classpath("application.conf")
+
+node-address {
+  host = sqs
+}
+
+queues {
+  queue1 {}
+}

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -5,11 +5,13 @@ services:
     ports:
     - "9911:9911"
     volumes:
-    - ./config:/etc/sns
+    - ./config/db.json:/etc/sns/db.json
     depends_on:
     - sqs
   sqs:
     image: s12v/elasticmq
     ports:
     - "9324:9324"
- 
+    volumes:
+    - ./config/elasticmq.conf:/etc/elasticmq/elasticmq.conf
+


### PR DESCRIPTION
The example docker-compose file is failing to publish to elasticmq. The log output
shows the message 'Connection refused'. This is because the Caml aws component will
first list the queues to get their urls. Elasticmq has not been configured with a
different host name so it will return "http://localhost:9324/queue/queue1" instead of
"http://sqs:9324/queue/queue1".