### PR TITLE
Always use POST for HTTP endpoints

### DIFF
--- a/src/main/scala/me/snov/sns/actor/ProducerActor.scala
+++ b/src/main/scala/me/snov/sns/actor/ProducerActor.scala
@@ -1,11 +1,11 @@
 package me.snov.sns.actor
 
 import akka.actor.{Actor, ActorLogging, Props}
-import akka.camel.{CamelMessage,Oneway}
-
+import akka.camel.{CamelMessage, Oneway}
 import spray.json._
-
 import me.snov.sns.model.Message
+import org.apache.camel.Exchange
+import org.apache.camel.component.http.HttpMethods
 
 object ProducerActor {
   def props(endpoint: String, subscriptionArn: String, topicArn: String) = Props(classOf[ProducerActor], endpoint, subscriptionArn, topicArn)
@@ -17,6 +17,7 @@ class ProducerActor(endpoint: String, subscriptionArn: String, topicArn: String)
   override def transformOutgoingMessage(msg: Any) = msg match {
     case snsMsg: Message => new CamelMessage(snsMsg.toJson.toString, Map(
         CamelMessage.MessageExchangeId -> snsMsg.uuid,
+        Exchange.HTTP_METHOD -> HttpMethods.POST,
         "x-amz-sns-message-type" -> "Notification",
         "x-amz-sns-message-id" -> snsMsg.uuid,
         "x-amz-sns-subscription-arn" -> subscriptionArn,


### PR DESCRIPTION
We noticed when adding a query parameter to our HTTP endpoint that the request was changing from a POST to a GET.

In the Camel documentation they detail why that might be happening in the [Calling using GET or POST](http://camel.apache.org/http4.html) section.

To get around that issue, we set a header to tell Camel to always use POST.