### PR TITLE
add TargetArn as valid destination for publish

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.0
+sbt.version=1.1.1

--- a/src/test/scala/me/snov/sns/api/PublishSpec.scala
+++ b/src/test/scala/me/snov/sns/api/PublishSpec.scala
@@ -42,6 +42,24 @@ class PublishSpec extends WordSpec with Matchers with ScalatestRouteTest {
     }
   }
 
+  "Sends publish command to TargetArn" in {
+    val params = Map(
+      "Action" -> "Publish",
+      "TargetArn" -> "foo",
+      "Message" -> "bar"
+    )
+
+    probe.setAutoPilot(new TestActor.AutoPilot {
+      def run(sender: ActorRef, msg: Any) = {
+        sender ! Message(Map("default" -> "foo"))
+        this
+      }
+    })
+    Post("/", FormData(params)) ~> route ~> check {
+      probe.expectMsg(CmdPublish("foo", Map("default" -> "bar"), Map.empty))
+    }
+  }
+
   "Sends publish command with attributes" in {
     val params = Map(
       "Action" -> "Publish",


### PR DESCRIPTION
Addressed issue: #46 

This PR adds `targetArn` besides to `topicArn` as additional valid destination-field to **publish** messages to the SNS.
